### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     branches: [ master, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/developmeh/mock-cors-server/security/code-scanning/1](https://github.com/developmeh/mock-cors-server/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions performed in the workflow, the following permissions are appropriate:
- `contents: read` for reading repository contents.
- `actions: write` for uploading artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within each job to customize permissions per job. In this case, adding it at the root level is sufficient and simplifies the configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
